### PR TITLE
add .markdownlint and its .vscode settings

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,9 @@
+{
+  "default": true,
+  "MD024": { "allow_different_nesting": true },
+  "MD029": { "style": "ordered" },
+  "ul-style": false,  # MD004
+  "line-length": false,  # MD013
+  "no-inline-html": false,  # MD033
+  "fenced-code-language": false  # MD040
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "rewrap.wrappingColumn": 80,
+    "editor.rulers": [80],
+    "markdownlint.config": {
+        "MD004": false,
+        "MD013": false,
+        "MD024": {"allow_different_nesting": true},
+        "MD029": {"style": "ordered"},
+        "MD033": false,
+        "MD040": false,
+    },
+}


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [X] Specification
- [ ] Examples
- [ ] Schema
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] Website
- [ ] SDK
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
providing markdown lint settings helps developers to catch format issues before submitting PRs, vscode settings conveniently highlight them when vscode markdownlint is used.

**Special notes for reviewers**:
Copied from https://github.com/open-telemetry/opentelemetry-specification/

**Additional information (if needed):**