### PR TITLE
Ability to define events as produced/consumed

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -268,9 +268,10 @@ Since function definitions are reusable, their data input parameters are defined
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | name | Unique event name | string | yes |
-| source | CloudEvent source | string | yes |
+| source | CloudEvent source | string | yes if kind is set to "consume", otherwise no |
 | type | CloudEvent type | string | yes |
 | correlationToken | Context attribute name of the CloudEvent which value is to be used for event correlation | string | no |
+| kind | Defines the events as either being consumed or produced by the workflow. Default is consumed. | enum | no |
 | [metadata](#Workflow-Metadata) | Metadata information | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
@@ -289,7 +290,8 @@ Since function definitions are reusable, their data input parameters are defined
    "name": "ApplicationSubmitted",
    "type": "org.application.submit",
    "source": "applicationssource",
-   "correlationToken": "applicantId"
+   "correlationToken": "applicantId",
+   "kind": "consumed"
 }
 ```
 
@@ -301,6 +303,7 @@ name: ApplicationSubmitted
 type: org.application.submit
 source: applicationssource
 correlationToken: applicantId
+kind: consumed
 ```
 
 </td>
@@ -310,16 +313,23 @@ correlationToken: applicantId
 </details>
 
 Defines events that can be consumed or produced during workflow execution.
-Consumed events can trigger actions to be executed. Events can also be produced during workflow
-execution to be consumed by clients.
 
-As serverless workflow definitions are vendor neutral, so should be the events definitions that they consume and produce.
-As such event format within serverless workflows uses the [CloudEvents](https://github.com/cloudevents/spec) specification to describe events.
+Consumed events can trigger creations of workflow instances, or continue execution of existing workflow instances.
+Workflows can produce events during their execution. These events can be then consumed by clients (or other workflows).
 
-To support use case where serverless workflows need to perform actions across multiple types
+Events defined must conform to the [CloudEvents](https://github.com/cloudevents/spec) specification. 
+This is to assure the consistency and portability of consumed or produced events.
+
+The event definition "kind" property defines if this event is consumed or produced. The default is consumed. 
+If the event is produced, implementations must provide the value of the event source when producing the CloudEvent.
+In this case (when "kind" is set to "produce") the "source" property of the event definition is not a required 
+property. Otherwise ("kind" is set to "consume") the "source" property must be defined.
+
+To support use case where workflows need to perform actions across multiple types
 of events, users can specify a correlation token to correlate these events.
-The "correlationToken" must specify a context attribute in the event which contains a business key to be
-used for event correlation. An event "context attribute" can be defined as any event attribute except the event payload (the event "data" attribute).
+The "correlationToken" property value must be the name of a context attribute in the event. This context attribute contains a business key to be
+used for event correlation. 
+An event "context attribute" can be defined as any event attribute except the event payload (the event "data" attribute).
 
 For example let's say we have two CloudEvent which set their correlation via the "patientId" context attribute:
 
@@ -2625,15 +2635,15 @@ data: "$.provisionedOrders"
 
 </details>
 
-Defines the CloudEvent to produce when workflow execution completes or during a workflow transition. 
+Defines the CloudEvent to be produce when workflow execution completes or during a workflow transition. 
 The "eventRef" property must match the name of
-one of the defined events in the [events](#Event-Definition) definition. From this the event type can be determined.
+one of the defined 'produce' events in the [events](#Event-Definition) definition.
+
 The data property defines a JSONPath expression which selects elements of the states data output to be placed into the
 data section of the produced CloudEvent.
 
 Being able to produce an event when workflow execution completes or during state transition
 allows for event-based orchestration communication.
-
 For example, completion of an orchestration workflow can notify other orchestration workflows to decide if they need to act upon
  the produced event. This can create very dynamic orchestration scenarios.
 
@@ -2658,7 +2668,8 @@ So the options for next state transitions are:
 - Use a combination of name and id properties
 
 Events can be produced during state transitions. The "produceEvent" property allows you
-to reference one of the defined workflow events and select the state data to be sent as the event payload.
+to reference one of the defined 'produce' events in the workflow [events definitions](#Event-Definition).
+It also allows you to select part of states data to be sent as the event payload.
 
 #### Restricting Transitions based on state output
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -268,7 +268,7 @@ Since function definitions are reusable, their data input parameters are defined
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | name | Unique event name | string | yes |
-| source | CloudEvent source | string | yes if kind is set to "consume", otherwise no |
+| source | CloudEvent source | string | yes if kind is set to "consumed", otherwise no |
 | type | CloudEvent type | string | yes |
 | correlationToken | Context attribute name of the CloudEvent which value is to be used for event correlation | string | no |
 | kind | Defines the events as either being consumed or produced by the workflow. Default is consumed. | enum | no |
@@ -322,8 +322,8 @@ This is to assure the consistency and portability of consumed or produced events
 
 The event definition "kind" property defines if this event is consumed or produced. The default is consumed. 
 If the event is produced, implementations must provide the value of the event source when producing the CloudEvent.
-In this case (when "kind" is set to "produce") the "source" property of the event definition is not a required 
-property. Otherwise ("kind" is set to "consume") the "source" property must be defined.
+In this case (when "kind" is set to "produced") the "source" property of the event definition is not a required 
+property. Otherwise ("kind" is set to "consumed") the "source" property must be defined.
 
 To support use case where workflows need to perform actions across multiple types
 of events, users can specify a correlation token to correlate these events.
@@ -2635,9 +2635,9 @@ data: "$.provisionedOrders"
 
 </details>
 
-Defines the CloudEvent to be produce when workflow execution completes or during a workflow transition. 
+Defines the CloudEvent to be produced when workflow execution completes or during a workflow transition. 
 The "eventRef" property must match the name of
-one of the defined 'produce' events in the [events](#Event-Definition) definition.
+one of the defined 'produced' events in the [events](#Event-Definition) definition.
 
 The data property defines a JSONPath expression which selects elements of the states data output to be placed into the
 data section of the produced CloudEvent.
@@ -2668,7 +2668,7 @@ So the options for next state transitions are:
 - Use a combination of name and id properties
 
 Events can be produced during state transitions. The "produceEvent" property allows you
-to reference one of the defined 'produce' events in the workflow [events definitions](#Event-Definition).
+to reference one of the defined 'produced' events in the workflow [events definitions](#Event-Definition).
 It also allows you to select part of states data to be sent as the event payload.
 
 #### Restricting Transitions based on state output

--- a/specification/examples/examples-brigade.md
+++ b/specification/examples/examples-brigade.md
@@ -571,7 +571,7 @@ events:
   type: exec
 - name: nextEvent
   type: next
-  kind: produce
+  kind: produced
 functions:
 - name: consoleLogFunction
   type: console

--- a/specification/examples/examples-brigade.md
+++ b/specification/examples/examples-brigade.md
@@ -571,6 +571,7 @@ events:
   type: exec
 - name: nextEvent
   type: next
+  kind: produce
 functions:
 - name: consoleLogFunction
   type: console

--- a/specification/examples/examples.md
+++ b/specification/examples/examples.md
@@ -1586,7 +1586,7 @@ CloudEvent upon completion of the workflow could look like:
 {
     "name": "provisioningCompleteEvent",
     "type": "provisionCompleteType",
-    "kind": "produce"
+    "kind": "produced"
 }
 ],
 "functions": [
@@ -1653,7 +1653,7 @@ name: Send CloudEvent on provision completion
 events:
 - name: provisioningCompleteEvent
   type: provisionCompleteType
-  kind: produce
+  kind: produced
 functions:
 - name: provisionOrderFunction
   resource: functionResourse

--- a/specification/examples/examples.md
+++ b/specification/examples/examples.md
@@ -1586,7 +1586,7 @@ CloudEvent upon completion of the workflow could look like:
 {
     "name": "provisioningCompleteEvent",
     "type": "provisionCompleteType",
-    "source": "provisionCompleteSource"
+    "kind": "produce"
 }
 ],
 "functions": [
@@ -1653,7 +1653,7 @@ name: Send CloudEvent on provision completion
 events:
 - name: provisioningCompleteEvent
   type: provisionCompleteType
-  source: provisionCompleteSource
+  kind: produce
 functions:
 - name: provisionOrderFunction
   resource: functionResourse

--- a/specification/roadmap/README.md
+++ b/specification/roadmap/README.md
@@ -58,3 +58,4 @@ _Status description:_
 | ✔️| Add Parallel State Exception Handling section | [spec doc](../README.md) |
 | ✔️| Add Go SDK | [sdk doc](../../sdk/go/README.md) |
 | ✔️| Add Java SDK | [sdk doc](../../sdk/java/README.md) |
+| ✔️| Allow to define events as produced or consumed | [spec doc](../README.md) |

--- a/specification/schema/events.json
+++ b/specification/schema/events.json
@@ -28,6 +28,12 @@
           "type": "string",
           "description": "CloudEvent type"
         },
+        "kind": {
+          "type" : "string",
+          "enum": ["consumed", "produced"],
+          "description": "Defines the events as either being consumed or produced by the workflow. Default is consumed",
+          "default": "consumed"
+        },
         "correlationToken": {
           "type": "string",
           "description": "Context attribute name of the CloudEvent which value is to be used for event correlation"
@@ -37,11 +43,26 @@
           "description": "Metadata information"
         }
       },
-      "required": [
-        "name",
-        "source",
-        "type"
-      ]
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "consumed"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "name",
+          "source",
+          "type"
+        ]
+      },
+      "else": {
+        "required": [
+          "name",
+          "type"
+        ]
+      }
     }
   }
 }

--- a/specification/schema/workflow.json
+++ b/specification/schema/workflow.json
@@ -119,7 +119,7 @@
           "$ref": "#/definitions/expression"
         },
         "produceEvent": {
-          "description": "Reference one of the defined events by name and set its data",
+          "description": "Reference one of the defined 'produce' events by name and set its data",
           "$ref": "#/definitions/produceevent"
         },
         "nextState": {
@@ -151,6 +151,58 @@
         "expression",
         "transition"
       ]
+    },
+    "eventdef": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique event name",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "description": "CloudEvent source"
+        },
+        "type": {
+          "type": "string",
+          "description": "CloudEvent type"
+        },
+        "kind": {
+          "type" : "string",
+          "enum": ["consume", "produce"],
+          "description": "Defines the events as either being consumed or produced by the workflow. Default is consumed",
+          "default": "consume"
+        },
+        "correlationToken": {
+          "type": "string",
+          "description": "Context attribute name of the CloudEvent which value is to be used for event correlation"
+        },
+        "metadata": {
+          "$ref": "common.json#/definitions/metadata",
+          "description": "Metadata information"
+        }
+      },
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "consume"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "name",
+          "source",
+          "type"
+        ]
+      },
+      "else": {
+        "required": [
+          "name",
+          "type"
+        ]
+      }
     },
     "eventactions": {
       "type": "object",
@@ -1564,7 +1616,7 @@
           "description": "Kind of end definition"
         },
         "produceEvent": {
-          "description": "If end kind is event, select one of the defined events by name and set its data",
+          "description": "If end kind is event, select one of the defined 'produce' events by name and set its data",
           "$ref": "#/definitions/produceevent"
         }
       },

--- a/specification/schema/workflow.json
+++ b/specification/schema/workflow.json
@@ -152,58 +152,6 @@
         "transition"
       ]
     },
-    "eventdef": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Unique event name",
-          "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "description": "CloudEvent source"
-        },
-        "type": {
-          "type": "string",
-          "description": "CloudEvent type"
-        },
-        "kind": {
-          "type" : "string",
-          "enum": ["consumed", "produced"],
-          "description": "Defines the events as either being consumed or produced by the workflow. Default is consumed",
-          "default": "consumed"
-        },
-        "correlationToken": {
-          "type": "string",
-          "description": "Context attribute name of the CloudEvent which value is to be used for event correlation"
-        },
-        "metadata": {
-          "$ref": "common.json#/definitions/metadata",
-          "description": "Metadata information"
-        }
-      },
-      "if": {
-        "properties": {
-          "kind": {
-            "const": "consumed"
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "name",
-          "source",
-          "type"
-        ]
-      },
-      "else": {
-        "required": [
-          "name",
-          "type"
-        ]
-      }
-    },
     "eventactions": {
       "type": "object",
       "properties": {

--- a/specification/schema/workflow.json
+++ b/specification/schema/workflow.json
@@ -119,7 +119,7 @@
           "$ref": "#/definitions/expression"
         },
         "produceEvent": {
-          "description": "Reference one of the defined 'produce' events by name and set its data",
+          "description": "Reference one of the defined 'produced' events by name and set its data",
           "$ref": "#/definitions/produceevent"
         },
         "nextState": {
@@ -170,9 +170,9 @@
         },
         "kind": {
           "type" : "string",
-          "enum": ["consume", "produce"],
+          "enum": ["consumed", "produced"],
           "description": "Defines the events as either being consumed or produced by the workflow. Default is consumed",
-          "default": "consume"
+          "default": "consumed"
         },
         "correlationToken": {
           "type": "string",
@@ -186,7 +186,7 @@
       "if": {
         "properties": {
           "kind": {
-            "const": "consume"
+            "const": "consumed"
           }
         }
       },
@@ -1616,7 +1616,7 @@
           "description": "Kind of end definition"
         },
         "produceEvent": {
-          "description": "If end kind is event, select one of the defined 'produce' events by name and set its data",
+          "description": "If end kind is event, select one of the defined 'produced' events by name and set its data",
           "$ref": "#/definitions/produceevent"
         }
       },


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x] Specification
- [x] Examples
- [x] Schema
- [x] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] Website
- [ ] SDK
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
This PR adresses Issue: https://github.com/cncf/wg-serverless-workflow/issues/29

It allows users to define an event definition as "produced" or "consumed" with a new "kind" property of the event definition.

If kind is "produce" the "source" property of the event definition is not required. Implementations
must set this property of the CE when the event is produced.

**Special notes for reviewers**:

**Additional information (if needed):**