### PR TITLE
Separating JSON Schema into multiple schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following documents are available:
 | **Core Specification:** | | |
 | Serverless Workflow| [v0.1](https://github.com/cncf/wg-serverless/blob/v0.1/workflow/spec/spec.md) | [master](specification/README.md)  |
 | **Additional Documentation:** | | |
-| Model JSON Schema | [v0.1](https://github.com/cncf/wg-serverless/blob/v0.1/workflow/spec/schema/serverless-workflow-schema-v01.json) | [master](specification/schema/serverless-workflow-schema.json) |
+| Model JSON Schema | [v0.1](https://github.com/cncf/wg-serverless/blob/v0.1/workflow/spec/schema/serverless-workflow-schema-v01.json) | [master](specification/schema/workflow.json) |
 
 ## Community
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -80,7 +80,7 @@ The Serverless workflow format is defined with [JSON](https://www.json.org/json-
 Structure of serverless workflows is described via [JSON Schema](https://json-schema.org/).
 
 Serverless Workflow definitions are considered specification-compliant if they conform to the 
-[workflow schema](schema/serverless-workflow-schema.json).
+[workflow schema](schema/workflow.json).
 
 Note that this schema reflects the current status of the specification as is updated alongside this document.
 
@@ -106,7 +106,7 @@ incoming events can trigger function invocations during workflow execution.
 
 ## Specification Goals
 
-At the core of the Serverless Workflow specification is its [JSON Schema](schema/serverless-workflow-schema.json).
+At the core of the Serverless Workflow specification is its [JSON Schema](schema/workflow.json).
 This schema defines the workflow model. It can also be used for generation of many different artifacts
 such as APIs, and SPIs. We plan to provide these in the near future, and hope to expand them 
 to many different languages. This speficiation also strives to soon provide a TCK with a set of tests which 
@@ -138,9 +138,9 @@ States can wait on the arrival events to perform their actions. When states
 complete their tasks, they can transition to other states or stop workflow execution.
 See the [Transitions](#Transitions) section for more details on workflow progression.
 
-A Serverless Workflow can be naturally implemented as a state machine or a workflow engine.
+A Serverless Workflow can be naturally implemented as a workflow engine.
 This specification does not mandate a specific implementation decision in this regard.
-As mentioned, implementation compliance is based on the workflow definition language only.
+Implementation compliance is based on the workflow definition language.
 
 ### Workflow Definition
 

--- a/specification/schema/common.json
+++ b/specification/schema/common.json
@@ -1,0 +1,13 @@
+{
+  "$id": "https://wg-serverless.org/serverless-workflow-common-schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Serverless Workflow is a vendor-neutral specification for defining the model of workflows responsible for orchestrating event-driven serverless applications",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "metadata": {
+      "type": "object",
+      "description": "Metadata information"
+    }
+  }
+}

--- a/specification/schema/events.json
+++ b/specification/schema/events.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://wg-serverless.org/serverless-workflow-events-schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Serverless Workflow is a vendor-neutral specification for defining the model of workflows responsible for orchestrating event-driven serverless applications",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "events": {
+      "type": "array",
+      "description": "Workflow event definitions. Defines events that can be consumed or produced",
+      "items": {
+        "type": "object",
+        "$ref": "#/definitions/eventdef"
+      }
+    },
+    "eventdef": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique event name",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "description": "CloudEvent source"
+        },
+        "type": {
+          "type": "string",
+          "description": "CloudEvent type"
+        },
+        "correlationToken": {
+          "type": "string",
+          "description": "Context attribute name of the CloudEvent which value is to be used for event correlation"
+        },
+        "metadata": {
+          "$ref": "common.json#/definitions/metadata",
+          "description": "Metadata information"
+        }
+      },
+      "required": [
+        "name",
+        "source",
+        "type"
+      ]
+    }
+  }
+}

--- a/specification/schema/functions.json
+++ b/specification/schema/functions.json
@@ -1,0 +1,42 @@
+{
+  "$id": "https://wg-serverless.org/serverless-workflow-functions-schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Serverless Workflow is a vendor-neutral specification for defining the model of workflows responsible for orchestrating event-driven serverless applications",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "functions": {
+      "type": "array",
+      "description": "Workflow function definitions",
+      "items": {
+        "type": "object",
+        "$ref": "#/definitions/function"
+      }
+    },
+    "function": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique function name",
+          "minLength": 1
+        },
+        "resource": {
+          "type": "string",
+          "description": "Function resource (URI)"
+        },
+        "type": {
+          "type": "string",
+          "description": "Function type"
+        },
+        "metadata": {
+          "$ref": "common.json#/definitions/metadata"
+        }
+      },
+      "required": [
+        "name",
+        "resource"
+      ]
+    }
+  }
+}

--- a/specification/schema/workflow.json
+++ b/specification/schema/workflow.json
@@ -44,23 +44,13 @@
       "description": "URI to JSON Schema that workflow data output adheres to"
     },
     "metadata": {
-      "$ref": "#/definitions/metadata"
+      "$ref": "common.json#/definitions/metadata"
     },
     "events": {
-      "type": "array",
-      "description": "Workflow event definitions. Defines events that can be consumed or produced",
-      "items": {
-        "type": "object",
-        "$ref": "#/definitions/eventdef"
-      }
+      "$ref": "events.json#/definitions/events"
     },
     "functions": {
-      "type": "array",
-      "description": "Workflow function definitions",
-      "items": {
-        "type": "object",
-        "$ref": "#/definitions/function"
-      }
+      "$ref": "functions.json#/definitions/functions"
     },
     "states": {
       "type": "array",
@@ -121,10 +111,6 @@
     "states"
   ],
   "definitions": {
-    "metadata": {
-      "type": "object",
-      "description": "Metadata information"
-    },
     "transition": {
       "type": "object",
       "properties": {
@@ -164,37 +150,6 @@
       "required": [
         "expression",
         "transition"
-      ]
-    },
-    "eventdef": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Unique event name",
-          "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "description": "CloudEvent source"
-        },
-        "type": {
-          "type": "string",
-          "description": "CloudEvent type"
-        },
-        "correlationToken": {
-          "type": "string",
-          "description": "Context attribute name of the CloudEvent which value is to be used for event correlation"
-        },
-        "metadata": {
-          "$ref": "#/definitions/metadata",
-          "description": "Metadata information"
-        }
-      },
-      "required": [
-        "name",
-        "source",
-        "type"
       ]
     },
     "eventactions": {
@@ -278,31 +233,6 @@
       },
       "required": [
         "expression"
-      ]
-    },
-    "function": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Unique function name",
-          "minLength": 1
-        },
-        "resource": {
-          "type": "string",
-          "description": "Function resource (URI)"
-        },
-        "type": {
-          "type": "string",
-          "description": "Function type"
-        },
-        "metadata": {
-          "$ref": "#/definitions/metadata"
-        }
-      },
-      "required": [
-        "name",
-        "resource"
       ]
     },
     "functionref": {
@@ -434,7 +364,7 @@
           "description": "URI to JSON Schema that state data output adheres to"
         },
         "metadata": {
-          "$ref": "#/definitions/metadata"
+          "$ref": "common.json#/definitions/metadata"
         }
       },
       "oneOf": [
@@ -553,7 +483,7 @@
           "description": "State end definition"
         },
         "metadata": {
-          "$ref": "#/definitions/metadata"
+          "$ref": "common.json#/definitions/metadata"
         }
       },
       "oneOf": [
@@ -672,7 +602,7 @@
           "description": "URI to JSON Schema that state data output adheres to"
         },
         "metadata": {
-          "$ref": "#/definitions/metadata"
+          "$ref": "common.json#/definitions/metadata"
         }
       },
       "oneOf": [
@@ -798,7 +728,7 @@
           "description": "URI to JSON Schema that state data output adheres to"
         },
         "metadata": {
-          "$ref": "#/definitions/metadata"
+          "$ref": "common.json#/definitions/metadata"
         }
       },
       "oneOf": [
@@ -911,7 +841,7 @@
           "description": "URI to JSON Schema that state data output adheres to"
         },
         "metadata": {
-          "$ref": "#/definitions/metadata"
+          "$ref": "common.json#/definitions/metadata"
         }
       },
       "oneOf": [
@@ -992,7 +922,7 @@
           "description": "URI to JSON Schema that state data output adheres to"
         },
         "metadata": {
-          "$ref": "#/definitions/metadata"
+          "$ref": "common.json#/definitions/metadata"
         }
       },
       "oneOf": [
@@ -1033,7 +963,7 @@
         "$ref": "#/definitions/eventdatafilter"
       },
       "metadata": {
-        "$ref": "#/definitions/metadata"
+        "$ref": "common.json#/definitions/metadata"
       },
       "required": ["eventRef", "transition"]
     },
@@ -1060,7 +990,7 @@
         }
       },
       "metadata": {
-        "$ref": "#/definitions/metadata"
+        "$ref": "common.json#/definitions/metadata"
       },
       "required": ["path", "value", "operator", "transition"]
     },
@@ -1127,7 +1057,7 @@
           "description": "URI to JSON Schema that state data output adheres to"
         },
         "metadata": {
-          "$ref": "#/definitions/metadata"
+          "$ref": "common.json#/definitions/metadata"
         }
       },
       "oneOf": [
@@ -1217,7 +1147,7 @@
           "description": "URI to JSON Schema that state data output adheres to"
         },
         "metadata": {
-          "$ref": "#/definitions/metadata"
+          "$ref": "common.json#/definitions/metadata"
         }
       },
       "oneOf": [
@@ -1377,7 +1307,7 @@
           "description": "URI to JSON Schema that state data output adheres to"
         },
         "metadata": {
-          "$ref": "#/definitions/metadata"
+          "$ref": "common.json#/definitions/metadata"
         }
       },
       "oneOf": [
@@ -1502,7 +1432,7 @@
           "description": "State end definition"
         },
         "metadata": {
-          "$ref": "#/definitions/metadata"
+          "$ref": "common.json#/definitions/metadata"
         }
       },
       "oneOf": [
@@ -1602,7 +1532,7 @@
           "kind"
         ]
       }
-    }, 
+    },
     "schedule": {
       "type": "object",
       "description": "Start state schedule definition",


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x] Specification
- [ ] Examples
- [x] Schema
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] Website
- [ ] SDK
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Currently we have one big schema for the entire workflow definition. 
At times users might want to validate against just the reusable function/events definitions.
This just separates the schema into multiple files (workflow.json, events.json, functions.json, and common.json) which makes this possible.

**Special notes for reviewers**:

**Additional information (if needed):**