### PR TITLE
Adding copyright in website footer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -192,8 +192,8 @@
     </div>
 </section>
 
-<footer class="page-footer font-small blue fixed-bottom">
-    <div class="footer-copyright text-center py-3" style="color: white;">© Serverless Workflow Specification Authors 2020 | Documentation Distributed under CC-BY-4.0<br/><br/>
+<footer class="page-footer font-small">
+    <div class="footer-copyright text-center py-3" style="color: 000000;">© Serverless Workflow Specification Authors 2020 | Documentation Distributed under CC-BY-4.0<br/><br/>
         © 2020 The Linux Foundation. All rights reserved.
         The Linux Foundation has registered trademarks and uses trademarks.<br/>
         For a list of trademarks of The Linux Foundation, please see our Trademark Usage page.

--- a/docs/index.html
+++ b/docs/index.html
@@ -192,14 +192,11 @@
     </div>
 </section>
 
-<!-- Footer -->
-<footer class="py-5 footer-custom">
-    <div class="container">
-        <a class="justify-content-left" href="https://www.cncf.io/" target="_blank">
-            <img src="img/cncf-white.png" width="220px"/></a>
-        &nbsp;&nbsp;
-        <a class="navbar-brand js-scroll-trigger justify-content-left" href="https://cloudevents.io/" target="_blank">
-            <img src="img/ce-logo-white.png" width="220px"/></a>
+<footer class="page-footer font-small blue fixed-bottom">
+    <div class="footer-copyright text-center py-3" style="color: white;">© Serverless Workflow Specification Authors 2020 | Documentation Distributed under CC-BY-4.0<br/><br/>
+        © 2020 The Linux Foundation. All rights reserved.
+        The Linux Foundation has registered trademarks and uses trademarks.<br/>
+        For a list of trademarks of The Linux Foundation, please see our Trademark Usage page.
     </div>
 </footer>
 


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ] Specification
- [ ] Examples
- [ ] Schema
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [x] Website
- [ ] SDK
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

Adds copyright to the website footer:

<img width="1127" alt="Screen Shot 2020-06-24 at 6 43 04 PM" src="https://user-images.githubusercontent.com/119422/85634901-9f059600-b64a-11ea-9c4b-6ce6e39f6025.png">



**Special notes for reviewers**:

**Additional information (if needed):**