### PR TITLE
Fix on default max field for the ForEach State

### DIFF
--- a/specification/schema/workflow.json
+++ b/specification/schema/workflow.json
@@ -1229,7 +1229,7 @@
         },
         "max": {
           "type": "integer",
-          "default": "0",
+          "default": 0,
           "minimum": 0,
           "description": "Specifies how upper bound on how many iterations may run in parallel"
         },


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x] Specification
- [ ] Examples
- [ ] Schema
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] Website
- [ ] SDK
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Wrong generation of Go types because the `default` field for the `max` property in the ForEach state was defined as string, being a integer.

**Special notes for reviewers**:
#28 depends on it