### PR TITLE
Java SDK - add 'produced'/'consumed' event definitions kind

### DIFF
--- a/sdk/java/api/src/main/java/io/cncf/serverlessworkflow/api/deserializers/EventDefinitionKindDeserializer.java
+++ b/sdk/java/api/src/main/java/io/cncf/serverlessworkflow/api/deserializers/EventDefinitionKindDeserializer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.cncf.serverlessworkflow.api.deserializers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import io.cncf.serverlessworkflow.api.events.EventDefinition;
+import io.cncf.serverlessworkflow.api.interfaces.WorkflowPropertySource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class EventDefinitionKindDeserializer extends StdDeserializer<EventDefinition.Kind> {
+    private static final long serialVersionUID = 510l;
+    private static Logger logger = LoggerFactory.getLogger(EventDefinitionKindDeserializer.class);
+
+    private WorkflowPropertySource context;
+
+    public EventDefinitionKindDeserializer() {
+        this(EventDefinition.Kind.class);
+    }
+
+    public EventDefinitionKindDeserializer(WorkflowPropertySource context) {
+        this(EventDefinition.Kind.class);
+        this.context = context;
+    }
+
+    public EventDefinitionKindDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public EventDefinition.Kind deserialize(JsonParser jp,
+                                            DeserializationContext ctxt) throws IOException {
+
+        String value = jp.getText();
+        if (context != null) {
+            try {
+                String result = context.getPropertySource().getProperty(value);
+
+                if (result != null) {
+                    return EventDefinition.Kind.fromValue(result);
+                } else {
+                    return EventDefinition.Kind.fromValue(jp.getText());
+                }
+            } catch (Exception e) {
+                logger.info("Exception trying to evaluate property: {}", e.getMessage());
+                return EventDefinition.Kind.fromValue(jp.getText());
+            }
+        } else {
+            return EventDefinition.Kind.fromValue(jp.getText());
+        }
+    }
+}

--- a/sdk/java/api/src/main/java/io/cncf/serverlessworkflow/api/mapper/WorkflowModule.java
+++ b/sdk/java/api/src/main/java/io/cncf/serverlessworkflow/api/mapper/WorkflowModule.java
@@ -18,6 +18,7 @@ package io.cncf.serverlessworkflow.api.mapper;
 
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.cncf.serverlessworkflow.api.deserializers.*;
+import io.cncf.serverlessworkflow.api.events.EventDefinition;
 import io.cncf.serverlessworkflow.api.events.EventsActions;
 import io.cncf.serverlessworkflow.api.interfaces.Extension;
 import io.cncf.serverlessworkflow.api.interfaces.State;
@@ -75,7 +76,9 @@ public class WorkflowModule extends SimpleModule {
                 new DefaultStateTypeDeserializer(workflowPropertySource));
         addDeserializer(DataCondition.Operator.class,
                 new DataConditionOperatorDeserializer(workflowPropertySource));
+        addDeserializer(EventDefinition.Kind.class, new EventDefinitionKindDeserializer(workflowPropertySource));
         addDeserializer(Extension.class, extensionDeserializer);
+
     }
 
     public ExtensionSerializer getExtensionSerializer() {

--- a/sdk/java/api/src/main/resources/schema/events/eventdef.json
+++ b/sdk/java/api/src/main/resources/schema/events/eventdef.json
@@ -19,13 +19,34 @@
       "type": "string",
       "description": "Context attribute name of the CloudEvent which value is to be used for event correlation"
     },
+    "kind": {
+      "type" : "string",
+      "enum": ["consumed", "produced"],
+      "description": "Defines the events as either being consumed or produced by the workflow. Default is consumed",
+      "default": "consumed"
+    },
     "metadata": {
       "$ref": "../metadata/metadata.json"
     }
   },
-  "required": [
-    "name",
-    "source",
-    "type"
-  ]
+  "if": {
+    "properties": {
+      "kind": {
+        "const": "consumed"
+      }
+    }
+  },
+  "then": {
+    "required": [
+      "name",
+      "source",
+      "type"
+    ]
+  },
+  "else": {
+    "required": [
+      "name",
+      "type"
+    ]
+  }
 }

--- a/sdk/java/api/src/test/java/io/cncf/serverlessworkflow/api/test/WorkflowToMarkupTest.java
+++ b/sdk/java/api/src/test/java/io/cncf/serverlessworkflow/api/test/WorkflowToMarkupTest.java
@@ -93,7 +93,8 @@ public class WorkflowToMarkupTest {
 
         Workflow workflow = new Workflow().withId("test-workflow").withName("test-workflow-name").withVersion("1.0")
                 .withEvents(Arrays.asList(
-                        new EventDefinition().withName("testEvent").withSource("testSource").withType("testType"))
+                        new EventDefinition().withName("testEvent").withSource("testSource").withType("testType")
+                        .withKind(EventDefinition.Kind.PRODUCED))
                 )
                 .withFunctions(Arrays.asList(
                         new Function().withName("testFunction").withResource("testResource").withType("testType"))
@@ -120,6 +121,7 @@ public class WorkflowToMarkupTest {
         assertNotNull(workflow.getEvents());
         assertEquals(1, workflow.getEvents().size());
         assertEquals("testEvent", workflow.getEvents().get(0).getName());
+        assertEquals(EventDefinition.Kind.PRODUCED, workflow.getEvents().get(0).getKind());
 
         assertNotNull(Workflow.toJson(workflow));
         assertNotNull(Workflow.toYaml(workflow));


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ] Specification
- [ ] Examples
- [ ] Schema
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] Website
- [x] SDK
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Updates Java SDK to https://github.com/cncf/wg-serverless-workflow/commit/2f7255d86149c04a7c6b9e58134f3cbd8e64c7e0

adds kind property to event definitions


**Special notes for reviewers**:

**Additional information (if needed):**